### PR TITLE
[WIP] Fixes for texlive and doxygen installation

### DIFF
--- a/linux/setup_centos_vm.sh
+++ b/linux/setup_centos_vm.sh
@@ -34,7 +34,7 @@ wget http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.8.src.tar.gz
 sudo yum remove doxygen -y # Remove yum version!  Necessary as otherwise might not overwrite.
 rpmbuild -ta doxygen-1.8.8.src.tar.gz --nodeps  # Use nodeps because we will eventually use a non-standard texlive installation with no RPM
 sudo yum install -y ~/rpmbuild/RPMS/x86_64/doxygen-1.8.8-1.x86_64.rpm
-echo "********** exclude=doxygen" | sudo tee --append /etc/yum.conf  # The hand-built RPM package has the wrong versioning scheme and by default will be overwritten by a yum update.  This prevents overwriting.
+echo "exclude=doxygen" | sudo tee --append /etc/yum.conf  # The hand-built RPM package has the wrong versioning scheme and by default will be overwritten by a yum update.  This prevents overwriting.
 doxygen --version  # Should be 1.8.8
 # Although we needed to have the redhat texlive installed to build the rpm, but we can delete the redhat texlive now.
 sudo yum remove texlive texlive-latex -y  # Get rid of the system texlive in preparation for latest version.


### PR DESCRIPTION
I found some residual bugs in our texlive installation pipeline.  
1.  The download sometimes fails, so it's useful to try the installer twice.  
2.  Don't install texlive from yum
3.  When building doxygen, we have to force ignore dependencies, as texlive is not going to be available as a yum package.  

(2/3) might not be strictly required, but I imagine the cleanest solution is to avoid having two overlapping texlive installs on the same VM, as it could possibly lead to strange PATH / tex include issues in the future.
[EDIT: don't merge just yet, still fixing some silly tex issues]
