### PR TITLE
Use latest conda

### DIFF
--- a/linux/setup_centos_vm.sh
+++ b/linux/setup_centos_vm.sh
@@ -85,8 +85,14 @@ sudo yum update -y  # Force a second update, in case CUDA has necessary patches.
 # Install Conda
 echo "********** Installing conda..."
 cd ~/Software
-wget http://repo.continuum.io/miniconda/Miniconda-3.7.0-Linux-x86_64.sh
-bash Miniconda-3.7.0-Linux-x86_64.sh -b
+MINICONDA=Miniconda-latest-Linux-x86_64.sh
+MINICONDA_MD5=$(curl -s http://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
+wget http://repo.continuum.io/miniconda/$MINICONDA
+if [[ $MINICONDA_MD5 != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
+echo "Miniconda MD5 mismatch"
+exit 1
+fi
+bash $MINICONDA -b
 
 # So there is a bug in some versions of anaconda where the path to swig files is HARDCODED.  Below is workaround.  See https://github.com/ContinuumIO/anaconda-issues/issues/48
 sudo ln -s  ~/miniconda/ /opt/anaconda1anaconda2anaconda3


### PR DESCRIPTION
1.  Conda usually upgrades itself on users machines, so I think we want to have our VM always grab the latest.
2.  This also gives greater consistency with the CI-code that runs on Travis--the code is copy-pasted from `install.sh`